### PR TITLE
fix: fix outputs for TS + JSDoc type checking (skip needing `*.d.ts`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,5 +12,6 @@ module.exports = {
   rules: {
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/triple-slash-reference': 'off',
   },
 }

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,16 +10,21 @@ This form is for reporting bugs or issues with content-scope-utils
 -->
 
 ## Description
+
 <!-- Description of the issue -->
 
 ## Steps to Reproduce
+
 <!-- How can we reproduce the bug ourselves -->
+
 1. step 1
 2. step 2
 3. ...
 
 **Expected behavior:**
+
 <!-- What you expect to happen -->
 
 **Actual behavior:**
+
 <!-- What actually happens -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,14 +4,15 @@
 
 <!-- Optional fields
 **CC:**
-**Depends on:** 
+**Depends on:**
 -->
 
 ## Description:
+
 <!-- Explain what is being changed, why, etc -->
 
-
 ## Steps to test this PR:
-<!-- List steps to test it manually 
-1. <STEP 1> 
+
+<!-- List steps to test it manually
+1. <STEP 1>
 -->

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,4 @@
 docs
 dist
+playwright-report
+.github

--- a/DOCS.md
+++ b/DOCS.md
@@ -6,10 +6,6 @@ DuckDuckGo Content Scope Utils is distributed under the Apache 2.0
 This is a library of JavaScript modules that are used by DuckDuckGo's apps and extensions.
 
 We currently support the following:
+
 - [Messaging](modules/Messaging)
-    
---- 
-
-## Development 
-
-
+  - [Webkit Messaging](modules/Webkit_Messaging)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 DuckDuckGo Content Scope Utils is distributed under the Apache 2.0
 [License](LICENSE.md).
 
-This is a library of JavaScript modules that are used by DuckDuckGo's apps and extensions. 
+This is a library of JavaScript modules that are used by DuckDuckGo's apps and extensions.
 
 [![Build Status](https://github.com/duckduckgo/content-scope-utils/actions/workflows/tests.yml/badge.svg)](https://github.com/duckduckgo/content-scope-utils/actions/workflows/tests.yml)
 
@@ -14,4 +14,5 @@ You can report security bugs through our [bounty program](https://hackerone.com/
 For more information, see [Reporting bugs](CONTRIBUTING.md#reporting-bugs).
 
 ## Questions?
+
 Visit our [help pages](https://help.duckduckgo.com/) for answers to common questions.

--- a/examples/bundled/index.html
+++ b/examples/bundled/index.html
@@ -1,14 +1,16 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport"
-        content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-  <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Messaging</title>
-</head>
-<body>
-<pre id="results"></pre>
-<script src="dist/messaging-consumer.dist.js"></script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Messaging</title>
+  </head>
+  <body>
+    <pre id="results"></pre>
+    <script src="dist/messaging-consumer.dist.js"></script>
+  </body>
 </html>

--- a/integration-tests/messaging.webkit.js
+++ b/integration-tests/messaging.webkit.js
@@ -1,110 +1,65 @@
-import { test, expect } from "@playwright/test";
-import { forwardConsole, withMockedWebkitHandlers } from "./test-helpers/webkit.js";
+import { expect, test } from '@playwright/test'
+import { BundledExamplePage } from './test-helpers/BundledExamplePage.js'
 
-test.describe("webkit modern messaging", () => {
-  test("runs when config provided", async ({ page }) => {
-    const bundled = new BundledPage(page);
+test.describe('webkit modern messaging', () => {
+  test('runs when config provided', async ({ page }) => {
+    const bundled = new BundledExamplePage(page)
     await bundled.withMocks({
-      getData: { id: "01" },
+      getData: { id: '01' },
       foo: null,
-    });
+    })
     await bundled.withInjectedConfig({
-      secret: "hello-world",
+      secret: 'hello-world',
       webkitMessageHandlerNames: [], // <-- not a requirement in modern mode
       hasModernWebkitAPI: true,
-    });
-    const outputs = await bundled.getPageOutputs();
-    expect(outputs).toMatchObject([["getData", { id: "01" }]]);
-  });
-});
-test.describe("webkit encrypted messaging", () => {
-  test("runs when config provided", async ({ page }) => {
-    const bundled = new BundledPage(page);
+    })
+    const outputs = await bundled.getPageOutputs()
+    expect(outputs).toMatchObject([['getData', { id: '01' }]])
+  })
+})
+test.describe('webkit encrypted messaging', () => {
+  test('runs when config provided', async ({ page }) => {
+    const bundled = new BundledExamplePage(page)
     await bundled.withMocks({
-      getData: { id: "01" },
+      getData: { id: '01' },
       foo: null,
-    });
+    })
     await bundled.withInjectedConfig({
-      secret: "hello-world",
-      webkitMessageHandlerNames: ["foo", "getData"],
+      secret: 'hello-world',
+      webkitMessageHandlerNames: ['foo', 'getData'],
       hasModernWebkitAPI: false,
-    });
-    const outputs = await bundled.getPageOutputs();
-    expect(outputs).toMatchObject([["getData", { id: "01" }]]);
-  });
-  test("fails when message handlers are absent (ie: missed/not added by native side)", async ({ page }) => {
-    const bundled = new BundledPage(page);
+    })
+    const outputs = await bundled.getPageOutputs()
+    expect(outputs).toMatchObject([['getData', { id: '01' }]])
+  })
+  test('fails when message handlers are absent (ie: missed/not added by native side)', async ({ page }) => {
+    const bundled = new BundledExamplePage(page)
     await bundled.withMocks({
       // empty mocks to simulate the message handlers not being available
-    });
+    })
     await bundled.withInjectedConfig({
-      secret: "hello-world",
+      secret: 'hello-world',
       webkitMessageHandlerNames: [], // <-- empty since we're mocking the fact that handler are absent
       hasModernWebkitAPI: false,
-    });
-    const outputs = await bundled.getPageOutputs();
+    })
+    const outputs = await bundled.getPageOutputs()
     expect(outputs).toMatchObject([
-      ["error", "Missing webkit handler: 'foo'"],
-      ["error", "Missing webkit handler: 'getData'"],
-    ]);
-  });
-  test("fails when message handler names are absent", async ({ page }) => {
-    const bundled = new BundledPage(page);
+      ['error', "Missing webkit handler: 'foo'"],
+      ['error', "Missing webkit handler: 'getData'"],
+    ])
+  })
+  test('fails when message handler names are absent', async ({ page }) => {
+    const bundled = new BundledExamplePage(page)
     await bundled.withMocks({
-      getData: { id: "01" },
+      getData: { id: '01' },
       foo: null,
-    });
+    })
     await bundled.withInjectedConfig({
-      secret: "hello-world",
-      webkitMessageHandlerNames: ["foo"], // <-- A missing handler name, so it won't be captured
+      secret: 'hello-world',
+      webkitMessageHandlerNames: ['foo'], // <-- A missing handler name, so it won't be captured
       hasModernWebkitAPI: false,
-    });
-    const outputs = await bundled.getPageOutputs();
-    expect(outputs).toMatchObject([["error", "cannot continue, method getData not captured on macos < 11"]]);
-  });
-});
-
-/**
- * This represents "examples/bundled/index.html"
- */
-class BundledPage {
-  /**
-   * @param {import("playwright-core").Page} page
-   */
-  constructor(page) {
-    this.page = page;
-    forwardConsole(page);
-  }
-
-  /**
-   * @param {import("../lib/messaging/webkit.js").WebkitMessagingConfig} config
-   */
-  async withInjectedConfig(config) {
-    const params = new URLSearchParams();
-    params.set("injected", JSON.stringify(config));
-    await this.page.goto("/?" + params.toString());
-  }
-
-  /**
-   * @param mocks
-   * @returns {Promise<void>}
-   */
-  async withMocks(mocks) {
-    await withMockedWebkitHandlers(this.page, mocks);
-  }
-
-  /**
-   * @returns {Promise<unknown[]>}
-   */
-  async getPageOutputs() {
-    return await this.page.evaluate(() => {
-      const outputs = [];
-      const elements = document.querySelectorAll("code");
-      for (let element of elements) {
-        const json = JSON.parse(element?.textContent || "{}");
-        outputs.push(json);
-      }
-      return outputs;
-    });
-  }
-}
+    })
+    const outputs = await bundled.getPageOutputs()
+    expect(outputs).toMatchObject([['error', 'cannot continue, method getData not captured on macos < 11']])
+  })
+})

--- a/integration-tests/test-helpers/BundledExamplePage.js
+++ b/integration-tests/test-helpers/BundledExamplePage.js
@@ -1,0 +1,46 @@
+import { forwardConsole, withMockedWebkitHandlers } from './webkit.js'
+
+/**
+ * This represents "examples/bundled/index.html"
+ */
+export class BundledExamplePage {
+  /**
+   * @param {import("playwright-core").Page} page
+   */
+  constructor(page) {
+    this.page = page
+    forwardConsole(page)
+  }
+
+  /**
+   * @param {import("../../lib/messaging/webkit.js").WebkitMessagingConfig} config
+   */
+  async withInjectedConfig(config) {
+    const params = new URLSearchParams()
+    params.set('injected', JSON.stringify(config))
+    await this.page.goto('/?' + params.toString())
+  }
+
+  /**
+   * @param {Record<string, any>} mocks
+   * @returns {Promise<void>}
+   */
+  async withMocks(mocks) {
+    await withMockedWebkitHandlers(this.page, mocks)
+  }
+
+  /**
+   * @returns {Promise<unknown[]>}
+   */
+  async getPageOutputs() {
+    return await this.page.evaluate(() => {
+      const outputs = []
+      const elements = document.querySelectorAll('code')
+      for (let element of elements) {
+        const json = JSON.parse(element?.textContent || '{}')
+        outputs.push(json)
+      }
+      return outputs
+    })
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+/// <reference path="./messaging/messaging.types.d.ts" />
 /**
  * @module Content Scope Utils
  *

--- a/lib/messaging.js
+++ b/lib/messaging.js
@@ -109,6 +109,7 @@ export class MessagingTransport {
    * @param {Record<string, any>} [data]
    * @returns {void}
    */
+  // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   notify(name, data = {}) {
     throw new Error("must implement 'notify'")
@@ -118,6 +119,7 @@ export class MessagingTransport {
    * @param {Record<string, any>} [data]
    * @return {Promise<any>}
    */
+  // @ts-ignore - ignoring a no-unused ts error, this is only an interface.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   request(name, data = {}) {
     throw new Error('must implement')

--- a/lib/messaging/messaging.types.d.ts
+++ b/lib/messaging/messaging.types.d.ts
@@ -1,13 +1,13 @@
 interface Window {
-  __playwright: MockCall[];
+  __playwright: MockCall[]
   webkit: {
     messageHandlers: Record<
       string,
       {
-        postMessage?: (...args: unknown[]) => void;
+        postMessage?: (...args: unknown[]) => void
       }
-    >;
-  };
+    >
+  }
 }
 
-type MockCall = [name: string, data: Record<string, unknown>, response: Record<string, unknown>];
+type MockCall = [name: string, data: Record<string, unknown>, response: Record<string, unknown>]

--- a/lib/messaging/webkit.js
+++ b/lib/messaging/webkit.js
@@ -168,16 +168,15 @@ export class WebkitMessagingTransport {
   /**
    * @param {string} name
    * @param {Record<string, any>} [data]
-   * @param {{signal?: AbortSignal}} [opts]
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  request(name, data = {}, opts = {}) {
+  request(name, data = {}) {
     return this.wkSendAndWait(name, data)
   }
   /**
    * Generate a random method name and adds it to the global scope
    * The native layer will use this method to send the response
-   * @param {string} randomMethodName
+   * @param {string | number} randomMethodName
    * @param {Function} callback
    */
   generateRandomMethod(randomMethodName, callback) {
@@ -191,6 +190,7 @@ export class WebkitMessagingTransport {
        */
       value: (...args) => {
         callback(...args)
+        // @ts-ignore - we want this to throw if it fails as it would indicate a fatal error.
         delete this.globals.window[randomMethodName]
       },
     })
@@ -364,6 +364,7 @@ function captureGlobals() {
     Promise: window.Promise,
     ObjectDefineProperty: window.Object.defineProperty,
     addEventListener: window.addEventListener.bind(window),
+    /** @type {Record<string, any>} */
     capturedWebkitHandlers: {},
   }
 }

--- a/lib/messaging/windows.js
+++ b/lib/messaging/windows.js
@@ -16,6 +16,7 @@ export class WindowsMessagingTransport {
    * @param {string} name
    * @param {Record<string, any>} [data]
    */
+  // @ts-ignore
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   notify(name, data = {}) {
     throw new Error('todo: implement notify for windows')
@@ -26,6 +27,7 @@ export class WindowsMessagingTransport {
    * @param {{signal?: AbortSignal}} opts
    * @return {Promise<any>}
    */
+  // @ts-ignore
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   request(name, data = {}, opts = {}) {
     throw new Error('todo: implement request for windows')

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docs.watch": "npm run docs -- --watch",
     "lint": "eslint .",
     "lint.write": "npm run lint -- --fix",
-    "prettier": "prettier 'lib/**/*.js' 'examples/**/*.js' '*.{cjs,js}'",
+    "prettier": "prettier .",
     "prettier.check": "npm run prettier -- --check",
     "prettier.write": "npm run prettier -- --write",
     "serve.example": "serve examples/bundled -p 5012",
@@ -26,7 +26,7 @@
     "test.integration": "cd examples/bundled && npm run build && cd - && playwright test",
     "tsc": "tsc",
     "tsc.watch": "tsc --watch",
-    "verify.local": "npm run docs; npm run lint.write; npm run prettier.write; npm run test.unit"
+    "verify.local": "npm run docs; npm run lint.write; npm run prettier.write; npm run tsc; npm run test.unit; npm run test.integration"
   },
   "type": "module",
   "repository": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,5 @@
-import type { PlaywrightTestConfig } from "@playwright/test";
-import { devices } from "@playwright/test";
+import type { PlaywrightTestConfig } from '@playwright/test'
+import { devices } from '@playwright/test'
 
 /**
  * Read environment variables from file.
@@ -11,7 +11,7 @@ import { devices } from "@playwright/test";
  * See https://playwright.dev/docs/test-configuration.
  */
 const config: PlaywrightTestConfig = {
-  testDir: "./integration-tests",
+  testDir: './integration-tests',
   /* Maximum time one test can run for. */
   timeout: 30 * 1000,
   expect: {
@@ -30,7 +30,7 @@ const config: PlaywrightTestConfig = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
@@ -39,15 +39,15 @@ const config: PlaywrightTestConfig = {
     // baseURL: 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: "on-first-retry",
+    trace: 'on-first-retry',
   },
 
   /* Configure projects for major browsers */
   projects: [
     {
-      name: "webkit",
+      name: 'webkit',
       use: {
-        ...devices["Desktop Safari"],
+        ...devices['Desktop Safari'],
       },
       testMatch: /\.webkit\.js$/,
     },
@@ -58,12 +58,12 @@ const config: PlaywrightTestConfig = {
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "npm run serve.example",
+    command: 'npm run serve.example',
     port: 5012,
     reuseExistingServer: true,
     ignoreHTTPSErrors: true,
     env: process.env as { [index: string]: string },
   },
-};
+}
 
-export default config;
+export default config

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,9 @@
     "strictNullChecks": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "noImplicitAny": false
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "include": ["lib", "integration-tests"]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,9 +1,5 @@
 {
-  "entryPoints": [
-    "lib/index.js",
-    "lib/messaging.js",
-    "lib/messaging/webkit.js"
-  ],
+  "entryPoints": ["lib/index.js", "lib/messaging.js", "lib/messaging/webkit.js"],
   "excludeExternals": true,
   "readme": "DOCS.md",
   "treatWarningsAsErrors": true,

--- a/unit-tests/messaging.test.js
+++ b/unit-tests/messaging.test.js
@@ -1,24 +1,24 @@
-import { expect } from "@esm-bundle/chai";
-import { Messaging } from "../lib/messaging.js";
-import { WindowsMessagingConfig, WindowsMessagingTransport } from "../lib/messaging/windows.js";
-import { WebkitMessagingConfig, WebkitMessagingTransport } from "../lib/messaging/webkit.js";
+import { expect } from '@esm-bundle/chai'
+import { Messaging } from '../lib/messaging.js'
+import { WindowsMessagingConfig, WindowsMessagingTransport } from '../lib/messaging/windows.js'
+import { WebkitMessagingConfig, WebkitMessagingTransport } from '../lib/messaging/webkit.js'
 
-it("can construct webkit messaging", async () => {
+it('can construct webkit messaging', async () => {
   const config = new WebkitMessagingConfig({
-    secret: "dax",
+    secret: 'dax',
     webkitMessageHandlerNames: [],
     hasModernWebkitAPI: true,
-  });
-  const messaging = new Messaging(config);
-  expect(messaging).to.be.instanceOf(Messaging);
-  expect(messaging.transport).to.be.instanceOf(WebkitMessagingTransport);
-});
+  })
+  const messaging = new Messaging(config)
+  expect(messaging).to.be.instanceOf(Messaging)
+  expect(messaging.transport).to.be.instanceOf(WebkitMessagingTransport)
+})
 
-it("can construct windows messaging", async () => {
+it('can construct windows messaging', async () => {
   const config = new WindowsMessagingConfig({
-    featureName: "DuckPlayer",
-  });
-  const messaging = new Messaging(config);
-  expect(messaging).to.be.instanceOf(Messaging);
-  expect(messaging.transport).to.be.instanceOf(WindowsMessagingTransport);
-});
+    featureName: 'DuckPlayer',
+  })
+  const messaging = new Messaging(config)
+  expect(messaging).to.be.instanceOf(Messaging)
+  expect(messaging.transport).to.be.instanceOf(WindowsMessagingTransport)
+})


### PR DESCRIPTION
## Description:
These are small tweaks/changes to ensure that other projects can consume this package without us needing to compile .d.ts files

